### PR TITLE
🔨 refactor(notifications): change Notification component to use styled-components

### DIFF
--- a/src/stories/notifications/_types.tsx
+++ b/src/stories/notifications/_types.tsx
@@ -1,11 +1,11 @@
 import { INotificationProps, IToastProviderProps } from "@zendeskgarden/react-notifications";
 
 export interface NotificationArgs extends INotificationProps {
-  /** Applies notification type styles */
-  type?: "success" | "warning" | "error" | "info";
+  type?: "success" | "error" | "warning" | "info";
+  isPrimary?: boolean;
+  children?: React.ReactNode | React.ReactNode[];
+  onClose?: () => void;
+  closeText?: string;
 }
 
-export interface ToastProviderArgs extends IToastProviderProps {
-  /** Applies regular (non-bold) font weight */
-  isRegular?: boolean;
-}
+export interface ToastProviderArgs extends IToastProviderProps {}

--- a/src/stories/notifications/index.stories.tsx
+++ b/src/stories/notifications/index.stories.tsx
@@ -1,43 +1,117 @@
 import { ComponentMeta, Story } from "@storybook/react";
-import { Notification } from ".";
+import {
+  Notification as UgNotification,
+  ToastProvider as UgToastProvider,
+  useToast,
+} from ".";
 import { Title } from "../title";
-import { Close } from "../close";
-import { NotificationArgs } from "./_types";
+import { NotificationArgs, ToastProviderArgs } from "./_types";
+import { useCallback } from "react";
+import { Grid } from "../grid/grid";
+import { Row } from "../grid/row";
+import { Col } from "../grid/col";
+import { Button } from "../buttons/button";
 
-interface NotificationStoryProps extends NotificationArgs {
-  title: string;
-  content: string;
+interface NotificationStoryProps {
+  notificationArgs: NotificationArgs;
+  toastProviderArgs: ToastProviderArgs;
 }
 
-const Template: Story<NotificationStoryProps> = ({
-  title,
-  content,
-  ...args
-}) => {
+const defaultArgs: NotificationStoryProps = {
+  notificationArgs: {
+    type: "warning",
+    children: <Title isRegular>Action completed</Title>,
+    onClose: () => alert("Close"),
+  },
+  toastProviderArgs: {
+    limit: 5,
+    zIndex: 1000,
+    placementProps: {
+      top: {
+        style: {
+          top: 60,
+        },
+      },
+    },
+  },
+};
+
+const Toasts = ({ children, onClose, ...props }: NotificationArgs) => {
+  const { addToast } = useToast();
+
+  const handleClick = useCallback(
+    (
+      placement:
+        | "top-start"
+        | "top"
+        | "top-end"
+        | "bottom-start"
+        | "bottom"
+        | "bottom-end"
+    ) => {
+      return () => {
+        addToast(
+          ({ close }) => (
+            <UgNotification
+              {...props}
+              onClose={() => {
+                onClose && onClose();
+                close();
+              }}
+            >
+              {children}
+            </UgNotification>
+          ),
+          { placement }
+        );
+      };
+    },
+    [addToast, props, children, onClose]
+  );
+
   return (
-    <Notification {...args}>
-      <Title>{title}</Title>
-      {content}
-      <Close aria-label="Close Notification" onClick={() => alert("Closed!")}/>
-    </Notification>
+    <Grid>
+      <Row>
+        <Col size="4"></Col>
+        <Col size="4">
+          <Button onClick={handleClick("top")} isStretched>
+            Show toast
+          </Button>
+        </Col>
+        <Col size="4"></Col>
+      </Row>
+    </Grid>
   );
 };
 
-const defaultArgs: NotificationStoryProps = {
-  type: "info",
-  title: "Info",
-  content:
-    "L'arancino siciliano comparve molto tardi nei ricettari che oggi conosciamo: nel XIX secolo.",
+const Template: Story<NotificationStoryProps> = ({
+  notificationArgs,
+  toastProviderArgs,
+}) => {
+  return (
+    <UgToastProvider {...toastProviderArgs}>
+      <Toasts {...notificationArgs} />
+    </UgToastProvider>
+  );
 };
 
-export const Default = Template.bind({});
-Default.args = defaultArgs;
+export const ToastProvider = Template.bind({});
+ToastProvider.args = defaultArgs;
+
+const NotificationTemplate: Story<NotificationArgs> = ({
+  children,
+  onClose,
+  ...props
+}) => <UgNotification {...props}>{children}</UgNotification>;
+
+export const Notification = NotificationTemplate.bind({});
+Notification.args = defaultArgs.notificationArgs;
 
 export default {
   title: "Molecules/Notification",
-  component: Notification,
+  component: UgNotification,
   parameters: {
     // Sets a delay for the component's stories
     chromatic: { delay: 300 },
   },
-} as ComponentMeta<typeof Notification>;
+} as ComponentMeta<typeof UgNotification>;

--- a/src/stories/notifications/index.tsx
+++ b/src/stories/notifications/index.tsx
@@ -4,6 +4,72 @@ import {
   useToast as ZendeskUseToast,
 } from "@zendeskgarden/react-notifications";
 import { NotificationArgs, ToastProviderArgs } from "./_types";
+import styled from "styled-components";
+import { Anchor } from "@zendeskgarden/react-buttons";
+
+const UgAnchor = styled(Anchor)`
+  cursor: pointer;
+`;
+
+const UgNotification = styled(ZendeskNotification)<NotificationArgs>`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+
+  > svg {
+    margin-top: 1px;
+  }
+
+  ${UgAnchor} {
+    flex-shrink: 0;
+    margin-left: ${({ theme }) => theme.space.md};
+  }
+
+  ${(props) =>
+    props.type === ("success" as NotificationArgs["type"]) &&
+    `
+    background-color: ${props.theme.palette.green[700]};
+    color: ${props.theme.palette.white};
+
+    *, *:hover, *:focus, *:active {
+      color: ${props.theme.palette.white} !important;
+    }
+  `}
+
+  ${(props) =>
+    props.type === ("error" as NotificationArgs["type"]) &&
+    `
+    background-color: ${props.theme.palette.red[600]};
+    color: ${props.theme.palette.white};
+
+    *, *:hover, *:focus, *:active {
+      color: ${props.theme.palette.white} !important;
+    }
+  `}
+
+  ${(props) =>
+    props.type === ("warning" as NotificationArgs["type"]) &&
+    `
+    background-color: ${props.theme.palette.yellow[600]};
+    color: ${props.theme.palette.white};
+
+    *, *:hover, *:focus, *:active {
+      color: ${props.theme.palette.white} !important;
+    }
+  `}
+
+  ${(props) =>
+    props.type === ("info" as NotificationArgs["type"]) &&
+    props.isPrimary &&
+    `
+    background-color: ${props.theme.palette.blue[600]};
+    color: ${props.theme.palette.white};
+
+    *, *:hover, *:focus, *:active {
+      color: ${props.theme.palette.white} !important;
+    }
+  `}
+`;
 
 /**
  * A Notification is a passive status update that keeps users informed of system progress.
@@ -11,12 +77,22 @@ import { NotificationArgs, ToastProviderArgs } from "./_types";
  * Used for this:
     - For a passive status update about user or system activity
  */
-const Notification = (props: NotificationArgs) => (
-  <ZendeskNotification {...props} />
+const Notification = ({
+  children,
+  closeText,
+  onClose,
+  ...props
+}: NotificationArgs) => (
+  <UgNotification {...props}>
+    {children}
+    <UgAnchor onClick={onClose}>{closeText ?? "Dismiss"}</UgAnchor>
+  </UgNotification>
 );
 
-//Extras
-const ToastProvider = (props: ToastProviderArgs) => <ZendeskToastProvider {...props}/>;
+// ToastProvider
+const ToastProvider = (props: ToastProviderArgs) => (
+  <ZendeskToastProvider {...props} />
+);
 const useToast = ZendeskUseToast;
 
 export { Notification, ToastProvider, useToast };


### PR DESCRIPTION
🔨 refactor(notifications): remove isRegular prop from ToastProviderArgs
🎨 style(notifications): add styles to Notification component
✨ feat(notifications): add closeText prop to NotificationArgs
✨ feat(notifications): add onClose prop to NotificationArgs
✨ feat(notifications): add children prop to NotificationArgs
✨ feat(notifications): add Toasts component to show notifications with useToast hook