### PR TITLE
Add useDebounce hook for bookmark updates in player controls

### DIFF
--- a/src/stories/player/parts/controls.tsx
+++ b/src/stories/player/parts/controls.tsx
@@ -12,6 +12,7 @@ import { useProgressContext } from "./progressContext";
 import { TimeLabel } from "./timeLabel";
 import { PlayerTooltip } from "./tooltip";
 import { formatDuration } from "./utils";
+import useDebounce from "../../../hooks/useDebounce";
 
 export const ControlsWrapper = styled.div<WrapperProps>`
   position: absolute;
@@ -65,8 +66,11 @@ export const Controls = ({
   const [tooltipMargin, setTooltipMargin] = useState<number>(0);
   const [tooltipLabel, setTooltipLabel] = useState<string>("00:00");
   const [marks, setMarks] = useState<IBookmark[] | undefined>(bookmarks);
+  const [updatedMark, setUpdatedMark] = useState<IBookmark>();
+
   const progressRef = useRef<HTMLDivElement>(null);
   const { context, setCurrentTime } = useVideoContext();
+  const debouncedMark = useDebounce(updatedMark, 500);
 
   const { reset, isGrabbing, activeBookmark, fromEnd } = useProgressContext();
 
@@ -154,16 +158,9 @@ export const Controls = ({
         ...marks.slice(currentObsIndex + 1),
       ];
       setMarks(newMarks);
-      onBookMarkUpdated?.(updatedMark);
+      setUpdatedMark(updatedMark);
     },
-    [
-      activeBookmark,
-      context.part.start,
-      duration,
-      fromEnd,
-      onBookMarkUpdated,
-      marks,
-    ]
+    [activeBookmark, context.part.start, duration, fromEnd, marks]
   );
 
   useEffect(() => {
@@ -179,6 +176,12 @@ export const Controls = ({
       document.removeEventListener("mouseup", reset);
     };
   }, [reset, marks]);
+
+  useEffect(() => {
+    if (debouncedMark) {
+      onBookMarkUpdated?.(debouncedMark);
+    }
+  }, [debouncedMark, onBookMarkUpdated]);
 
   return (
     <ControlsWrapper isPlaying={context.isPlaying}>
@@ -205,10 +208,7 @@ export const Controls = ({
       <ControlsBar>
         <StyledDiv style={{ width: "20%", justifyContent: "start" }}>
           <AudioButton />
-          <TimeLabel
-            current={relCurrentTime}
-            duration={duration}
-          />
+          <TimeLabel current={relCurrentTime} duration={duration} />
         </StyledDiv>
         <ControlsGroupCenter style={{ width: "60%" }} />
 


### PR DESCRIPTION
This pull request adds a new custom hook called `useDebounce` to handle debouncing of bookmark updates in the player controls. The `useDebounce` hook is used to delay the execution of the `onBookMarkUpdated` function when a bookmark is updated, preventing unnecessary updates. This improves the performance and responsiveness of the player controls.