### PR TITLE
Add PlanTag component for plan status display

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -153,6 +153,9 @@ export * from "./stories/player";
 // --- PlanCard ---
 export { PlanCard } from "./stories/cards/plan-cards";
 
+// --- PlanStatus ---
+export { PlanTag } from "./stories/cards/plan-cards/parts/tag";
+
 // --- TemplateCard ---
 export { TemplateCard } from "./stories/cards/template-card";
 

--- a/src/stories/cards/plan-cards/_types.tsx
+++ b/src/stories/cards/plan-cards/_types.tsx
@@ -1,6 +1,6 @@
 import { SpecialCardProps } from "../../special-cards/_types";
 
-export type IPlanStatus = "draft" | "submitted" | "pending_quote_review";
+export type IPlanStatus = "draft" | "submitted" | "pending_quote_review" | "approved";
 
 export interface PlanCardsProps extends SpecialCardProps {
   /**

--- a/src/stories/cards/plan-cards/icons/approved-status.svg
+++ b/src/stories/cards/plan-cards/icons/approved-status.svg
@@ -1,0 +1,9 @@
+<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect x="0.666992" width="24" height="24" rx="12" fill="#F6F6F8" />
+    <path
+        d="M11.8936 13.0313H15.664M11.8936 9.26075V13.0313V9.26075ZM11.8936 13.0313L20.788 5.03906L11.8936 13.0313Z"
+        stroke="#1466A9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+    <path
+        d="M16.1583 4.52345C15.0977 4.02723 13.9142 3.75002 12.666 3.75002C8.10967 3.75002 4.41602 7.44367 4.41602 12C4.41602 16.5563 8.10967 20.25 12.666 20.25C17.2223 20.25 20.916 16.5563 20.916 12C20.916 11.2878 20.8258 10.5968 20.6561 9.93752"
+        stroke="#6AB4E2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/src/stories/cards/plan-cards/parts/tag/index.stories.tsx
+++ b/src/stories/cards/plan-cards/parts/tag/index.stories.tsx
@@ -1,0 +1,38 @@
+import { Meta as ComponentMeta, StoryFn as Story } from "@storybook/react";
+import { Col } from "../../../../grid/col";
+import { Row } from "../../../../grid/row";
+import { IPlanTagProps, PlanTag } from ".";
+
+interface TagStoryProps extends IPlanTagProps {
+  children: string;
+}
+
+const Template: Story<TagStoryProps> = ({ children, ...args }) => (
+  <Row>
+    <Col textAlign="center">
+      <PlanTag status={args.status ?? "draft"} statusLabel={children} />
+    </Col>
+  </Row>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  children: "Questo è un tag",
+};
+
+export default {
+  title: "Atoms/Tag/PlanTag",
+  component: PlanTag,
+  parameters: {
+    // Sets a delay for the component's stories
+    chromatic: { delay: 300 },
+  },
+  argTypes: {
+    status: {
+      control: {
+        type: "select",
+        options: ["draft", "submitted", "pending_quote_review", "approved"],
+      },
+    },
+  },
+} as ComponentMeta<typeof PlanTag>;

--- a/src/stories/cards/plan-cards/parts/tag/index.tsx
+++ b/src/stories/cards/plan-cards/parts/tag/index.tsx
@@ -1,10 +1,15 @@
-import { Tag } from "../../../tags";
-import { theme } from "../../../theme";
-import { IPlanStatus } from "../_types";
-import { ReactComponent as DraftStatusIcon } from "../icons/draft-status.svg";
-import { ReactComponent as SubmittedStatusIcon } from "../icons/submitted-status.svg";
-import { ReactComponent as WaitingStatusIcon } from "../icons/waiting-status.svg";
+import { Tag } from "../../../../tags";
+import { theme } from "../../../../theme";
+import { IPlanStatus } from "../../_types";
+import { ReactComponent as DraftStatusIcon } from "../../icons/draft-status.svg";
+import { ReactComponent as SubmittedStatusIcon } from "../../icons/submitted-status.svg";
+import { ReactComponent as WaitingStatusIcon } from "../../icons/waiting-status.svg";
+import { ReactComponent as ApprovedStatusIcon } from "../../icons/approved-status.svg";
 
+export interface IPlanTagProps {
+  status: IPlanStatus;
+  statusLabel: string;
+}
 /**
  * Almost duplicated getTitleColor switch cause design requires slightly different colors
  * for the status tag.
@@ -15,18 +20,14 @@ const getTagColor = (status: IPlanStatus) => {
       return theme.palette.grey[800];
     case "pending_quote_review":
       return theme.palette.yellow[700];
+    case "approved":
+      return theme.palette.azure[600];
     default:
       return theme.palette.azure[800];
   }
 };
 
-export const PlanTag = ({
-  status,
-  statusLabel,
-}: {
-  status: IPlanStatus;
-  statusLabel: string;
-}) => {
+export const PlanTag = ({ status, statusLabel }: IPlanTagProps) => {
   const color = getTagColor(status);
 
   const Icon = (() => {
@@ -35,6 +36,8 @@ export const PlanTag = ({
         return <SubmittedStatusIcon />;
       case "pending_quote_review":
         return <WaitingStatusIcon />;
+      case "approved":
+        return <ApprovedStatusIcon />;
       default:
         return <DraftStatusIcon />;
     }


### PR DESCRIPTION
Introduce the PlanTag component to visually represent plan statuses with corresponding icons, enhancing the user interface. Update the IPlanStatus type to include an "approved" status.