### PR TITLE
feat(player): add disable and tooltip support to Cutter button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# v4.1.1 (Mon Jun 15 2026)
+
+#### 🐛 Bug Fix
+
+- release 20260615 [#598](https://github.com/AppQuality/unguess-design-system/pull/598) ([@iacopolea](https://github.com/iacopolea) [@marcbon](https://github.com/marcbon))
+- feat: update version to 4.1.1-canary and add File component to forms [#597](https://github.com/AppQuality/unguess-design-system/pull/597) ([@iacopolea](https://github.com/iacopolea))
+
+#### Authors: 2
+
+- Iacopo Leardini ([@iacopolea](https://github.com/iacopolea))
+- Marco Bonomo ([@marcbon](https://github.com/marcbon))
+
+---
+
 # v4.1.0 (Wed May 13 2026)
 
 #### 🚀 Enhancement

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appquality/unguess-design-system",
-  "version": "4.1.0",
+  "version": "4.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appquality/unguess-design-system",
-      "version": "4.1.0",
+      "version": "4.1.2",
       "license": "ISC",
       "dependencies": {
         "@appquality/stream-player": "1.0.109",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appquality/unguess-design-system",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/stories/player/_types.tsx
+++ b/src/stories/player/_types.tsx
@@ -14,6 +14,8 @@ export interface PlayerArgs extends HTMLAttributes<HTMLVideoElement> {
   i18n?: PlayerI18n;
   showControls?: boolean;
   onShortcut?: (type: string) => void;
+  disableCutter?: boolean;
+  cutterTooltipText?: string;
 }
 
 export interface PlayerI18n {

--- a/src/stories/player/index.stories.tsx
+++ b/src/stories/player/index.stories.tsx
@@ -237,6 +237,13 @@ WithBookmarks.args = {
   },
 };
 
+export const CutterDisabled = TemplateWithCutter.bind({});
+CutterDisabled.args = {
+  ...AudioPlayerWithBookmarks.args,
+  disableCutter: true,
+  cutterTooltipText: "Available once the transcript is ready",
+};
+
 export const WithContext = TemplateWithContext.bind({});
 WithContext.args = { ...defaultArgs };
 

--- a/src/stories/player/index.tsx
+++ b/src/stories/player/index.tsx
@@ -39,6 +39,8 @@ const PlayerCore = forwardRef<HTMLVideoElement, PlayerArgs>(
       pipMode,
       onPipChange,
       playerType = "video",
+      disableCutter,
+      cutterTooltipText,
     } = props;
     const videoRef = context.player?.ref.current;
     const isLoaded = !!videoRef;
@@ -103,6 +105,8 @@ const PlayerCore = forwardRef<HTMLVideoElement, PlayerArgs>(
             onBookMarkUpdated={props.handleBookmarkUpdate}
             i18n={props.i18n}
             playerType={playerType}
+            disableCutter={disableCutter}
+            cutterTooltipText={cutterTooltipText}
           />
         </ProgressContextProvider>
       </Container>

--- a/src/stories/player/parts/controls.tsx
+++ b/src/stories/player/parts/controls.tsx
@@ -73,6 +73,8 @@ export const Controls = ({
   i18n,
   showControls = false,
   playerType = "video",
+  disableCutter,
+  cutterTooltipText,
 }: {
   container: HTMLDivElement | null;
   onCutHandler?: (time: number) => void;
@@ -82,6 +84,8 @@ export const Controls = ({
   i18n?: PlayerI18n;
   showControls?: boolean;
   playerType?: "video" | "audio";
+  disableCutter?: boolean;
+  cutterTooltipText?: string;
 }) => {
   const [progress, setProgress] = useState<number>(0);
   const [tooltipMargin, setTooltipMargin] = useState<number>(0);
@@ -253,6 +257,8 @@ export const Controls = ({
             onCutHandler={onCutHandler}
             isCutting={isCutting}
             i18n={i18n}
+            disable={disableCutter}
+            tooltipText={cutterTooltipText}
           />
           {playerType === "video" && <FullScreenButton container={container} />}
         </StyledDiv>

--- a/src/stories/player/parts/cutterButton.tsx
+++ b/src/stories/player/parts/cutterButton.tsx
@@ -6,21 +6,30 @@ import { Tooltip } from "../../tooltip";
 import { Span } from "../../typography/span";
 import { PlayerI18n } from "../_types";
 import { ReactComponent as PlusIcon } from "../assets/plus.svg";
-import { PlayerShortCut } from "../shortcuts";
 
 // Prevent button from breaking on smaller screens
 const StyledButton = styled(Button)`
   overflow: visible;
 `;
 
+// Disabled buttons don't fire mouse events, so the Tooltip needs
+// a non-disabled wrapper to trigger on hover
+const TooltipTrigger = styled.span`
+  display: inline-block;
+`;
+
 export const Cutter = ({
   onCutHandler,
   isCutting,
   i18n,
+  disable = false,
+  tooltipText,
 }: {
   onCutHandler?: (time: number) => void;
   isCutting?: boolean;
   i18n?: PlayerI18n;
+  disable?: boolean;
+  tooltipText?: string;
 }) => {
   const { context } = useVideoContext();
 
@@ -28,43 +37,41 @@ export const Cutter = ({
 
   if (!onCutHandler) return null;
 
-  return (
-    <Tooltip
-      type="light"
-      size="medium"
-      maxWidth="unset"
-      content={
-        <PlayerShortCut type="observation">
-          {i18n?.observations || "Start/stop new observation"}
-        </PlayerShortCut>
-      }
+  const button = (
+    <StyledButton
+      isPrimary
+      isAccent={!isCutting}
+      disabled={disable}
+      onClick={(e) => {
+        if (videoRef) {
+          onCutHandler(videoRef.currentTime);
+        }
+        e.stopPropagation();
+      }}
     >
-      <StyledButton
-        isPrimary
-        isAccent={!isCutting}
-        onClick={(e) => {
-          if (videoRef) {
-            onCutHandler(videoRef.currentTime);
-          }
-          e.stopPropagation();
-        }}
-      >
-        {isCutting ? (
-          <>
-            <Button.StartIcon>
-              <TagIcon />
-            </Button.StartIcon>
-            <Span>{i18n?.onHighlight || "End observation"}</Span>
-          </>
-        ) : (
-          <>
-            <Button.StartIcon>
-              <PlusIcon />
-            </Button.StartIcon>
-            <Span>{i18n?.beforeHighlight || "Start observation"}</Span>
-          </>
-        )}
-      </StyledButton>
+      {isCutting ? (
+        <>
+          <Button.StartIcon>
+            <TagIcon />
+          </Button.StartIcon>
+          <Span>{i18n?.onHighlight || "End observation"}</Span>
+        </>
+      ) : (
+        <>
+          <Button.StartIcon>
+            <PlusIcon />
+          </Button.StartIcon>
+          <Span>{i18n?.beforeHighlight || "Start observation"}</Span>
+        </>
+      )}
+    </StyledButton>
+  );
+
+  if (!tooltipText) return button;
+
+  return (
+    <Tooltip type="light" size="medium" maxWidth="unset" content={tooltipText}>
+      <TooltipTrigger>{button}</TooltipTrigger>
     </Tooltip>
   );
 };

--- a/src/stories/player/parts/cutterButton.tsx
+++ b/src/stories/player/parts/cutterButton.tsx
@@ -14,9 +14,8 @@ const StyledButton = styled(Button)`
 
 // Disabled buttons don't fire mouse events, so the Tooltip needs
 // a non-disabled wrapper to trigger on hover
-const TooltipTrigger = styled.span`
-  display: inline-block;
-`;
+// we create a styled div with a specific id to append the tooltip to, so that it doesn't get cut off by the player container
+const TooltipTrigger = styled.div.attrs({ id: "cutter-tooltip-trigger" })``;
 
 export const Cutter = ({
   onCutHandler,
@@ -69,8 +68,10 @@ export const Cutter = ({
 
   if (!tooltipText) return button;
 
+  const appendTo = document.getElementById("cutter-tooltip-trigger") || undefined;
+
   return (
-    <Tooltip type="light" size="medium" maxWidth="unset" content={tooltipText}>
+    <Tooltip type="light" size="medium" maxWidth="unset" content={tooltipText} appendToNode={appendTo}>
       <TooltipTrigger>{button}</TooltipTrigger>
     </Tooltip>
   );


### PR DESCRIPTION
## Summary
- Add `disable` prop (default `false`) to the Cutter button, disabling the underlying button
- Add `tooltipText` prop: when provided, wraps the button in a Tooltip showing that text; when omitted, no tooltip is rendered
- Wire both props through Player -> Controls -> Cutter (as `disableCutter` / `cutterTooltipText`)
- Add a wrapper span around the button so hover tooltips still work when the button is disabled (native `disabled` buttons don't fire mouse events)

## Test plan
- [ ] Storybook: "Organisms/Player" -> "Cutter Disabled" story shows the button disabled with tooltip on hover
- [ ] Storybook: existing Cutter stories (no tooltipText) show no tooltip