### PR TITLE
fix(player): unify observations tooltip and disable shortcut when Cutter is disabled

### DIFF
--- a/src/stories/player/_types.tsx
+++ b/src/stories/player/_types.tsx
@@ -23,6 +23,7 @@ export interface PlayerI18n {
   playpause?: string;
   mute?: string;
   observations?: string;
+  observationsDisable?: string;
   forward?: string;
   backward?: string;
 }

--- a/src/stories/player/_types.tsx
+++ b/src/stories/player/_types.tsx
@@ -15,7 +15,6 @@ export interface PlayerArgs extends HTMLAttributes<HTMLVideoElement> {
   showControls?: boolean;
   onShortcut?: (type: string) => void;
   disableCutter?: boolean;
-  cutterTooltipText?: string;
 }
 
 export interface PlayerI18n {

--- a/src/stories/player/hooks/useKeyboardCommands.ts
+++ b/src/stories/player/hooks/useKeyboardCommands.ts
@@ -4,11 +4,13 @@ type KeyboardCommandsHook = ({
   setIsPlaying,
   onCutHandler,
   videoRef,
+  disableCutter,
 }: {
   setIsPlaying: (isPlaying: boolean) => void;
   onCutHandler?: (time: number) => void;
   onShortcut?: (type: string) => void;
   videoRef?: HTMLVideoElement | null;
+  disableCutter?: boolean;
 }) => void;
 
 export const useKeyboardCommands: KeyboardCommandsHook = ({
@@ -16,6 +18,7 @@ export const useKeyboardCommands: KeyboardCommandsHook = ({
   onCutHandler,
   onShortcut,
   videoRef,
+  disableCutter,
 }) => {
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -50,7 +53,7 @@ export const useKeyboardCommands: KeyboardCommandsHook = ({
         videoRef.volume = videoRef.muted ? 0 : 1;
         onShortcut?.("mute");
       }
-      if (e.code === "KeyS") {
+      if (e.code === "KeyS" && !disableCutter) {
         onCutHandler?.(videoRef.currentTime);
         e.stopPropagation();
         onShortcut?.("start/stop_observation");
@@ -60,5 +63,5 @@ export const useKeyboardCommands: KeyboardCommandsHook = ({
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [videoRef, onCutHandler]);
+  }, [videoRef, onCutHandler, disableCutter]);
 };

--- a/src/stories/player/index.stories.tsx
+++ b/src/stories/player/index.stories.tsx
@@ -241,7 +241,7 @@ export const CutterDisabled = TemplateWithCutter.bind({});
 CutterDisabled.args = {
   ...AudioPlayerWithBookmarks.args,
   disableCutter: true,
-  i18n: { observations: "Available once the transcript is ready" },
+  i18n: { observationsDisable: "Available once the transcript is ready" },
 };
 
 export const WithContext = TemplateWithContext.bind({});

--- a/src/stories/player/index.stories.tsx
+++ b/src/stories/player/index.stories.tsx
@@ -241,7 +241,7 @@ export const CutterDisabled = TemplateWithCutter.bind({});
 CutterDisabled.args = {
   ...AudioPlayerWithBookmarks.args,
   disableCutter: true,
-  cutterTooltipText: "Available once the transcript is ready",
+  i18n: { observations: "Available once the transcript is ready" },
 };
 
 export const WithContext = TemplateWithContext.bind({});

--- a/src/stories/player/index.stories.tsx
+++ b/src/stories/player/index.stories.tsx
@@ -256,6 +256,9 @@ export default {
       description: "The url of the video to play",
       control: "text",
     },
+    i18n: {
+      control: "object",
+    },
   },
   parameters: {
     chromatic: { delay: 300 },

--- a/src/stories/player/index.tsx
+++ b/src/stories/player/index.tsx
@@ -40,7 +40,6 @@ const PlayerCore = forwardRef<HTMLVideoElement, PlayerArgs>(
       onPipChange,
       playerType = "video",
       disableCutter,
-      cutterTooltipText,
     } = props;
     const videoRef = context.player?.ref.current;
     const isLoaded = !!videoRef;
@@ -106,7 +105,6 @@ const PlayerCore = forwardRef<HTMLVideoElement, PlayerArgs>(
             i18n={props.i18n}
             playerType={playerType}
             disableCutter={disableCutter}
-            cutterTooltipText={cutterTooltipText}
           />
         </ProgressContextProvider>
       </Container>

--- a/src/stories/player/index.tsx
+++ b/src/stories/player/index.tsx
@@ -54,6 +54,7 @@ const PlayerCore = forwardRef<HTMLVideoElement, PlayerArgs>(
       onCutHandler,
       videoRef,
       onShortcut: props.onShortcut,
+      disableCutter,
     });
     usePictureInPicture(
       videoRef,

--- a/src/stories/player/parts/controls.tsx
+++ b/src/stories/player/parts/controls.tsx
@@ -74,7 +74,6 @@ export const Controls = ({
   showControls = false,
   playerType = "video",
   disableCutter,
-  cutterTooltipText,
 }: {
   container: HTMLDivElement | null;
   onCutHandler?: (time: number) => void;
@@ -85,7 +84,6 @@ export const Controls = ({
   showControls?: boolean;
   playerType?: "video" | "audio";
   disableCutter?: boolean;
-  cutterTooltipText?: string;
 }) => {
   const [progress, setProgress] = useState<number>(0);
   const [tooltipMargin, setTooltipMargin] = useState<number>(0);
@@ -258,7 +256,6 @@ export const Controls = ({
             isCutting={isCutting}
             i18n={i18n}
             disable={disableCutter}
-            tooltipText={cutterTooltipText}
           />
           {playerType === "video" && <FullScreenButton container={container} />}
         </StyledDiv>

--- a/src/stories/player/parts/cutterButton.tsx
+++ b/src/stories/player/parts/cutterButton.tsx
@@ -6,6 +6,7 @@ import { Tooltip } from "../../tooltip";
 import { Span } from "../../typography/span";
 import { PlayerI18n } from "../_types";
 import { ReactComponent as PlusIcon } from "../assets/plus.svg";
+import { PlayerShortCut } from "../shortcuts";
 
 // Prevent button from breaking on smaller screens
 const StyledButton = styled(Button)`
@@ -22,13 +23,11 @@ export const Cutter = ({
   isCutting,
   i18n,
   disable = false,
-  tooltipText,
 }: {
   onCutHandler?: (time: number) => void;
   isCutting?: boolean;
   i18n?: PlayerI18n;
   disable?: boolean;
-  tooltipText?: string;
 }) => {
   const { context } = useVideoContext();
 
@@ -66,12 +65,20 @@ export const Cutter = ({
     </StyledButton>
   );
 
-  if (!tooltipText) return button;
-
   const appendTo = document.getElementById("cutter-tooltip-trigger") || undefined;
 
   return (
-    <Tooltip type="light" size="medium" maxWidth="unset" content={tooltipText} appendToNode={appendTo}>
+    <Tooltip
+      type="light"
+      size="medium"
+      maxWidth="unset"
+      appendToNode={appendTo}
+      content={
+        <PlayerShortCut type="observation">
+          {i18n?.observations || "Start/stop new observation"}
+        </PlayerShortCut>
+      }
+    >
       <TooltipTrigger>{button}</TooltipTrigger>
     </Tooltip>
   );

--- a/src/stories/player/parts/cutterButton.tsx
+++ b/src/stories/player/parts/cutterButton.tsx
@@ -74,9 +74,13 @@ export const Cutter = ({
       maxWidth="unset"
       appendToNode={appendTo}
       content={
-        <PlayerShortCut type="observation">
-          {i18n?.observations || "Start/stop new observation"}
-        </PlayerShortCut>
+        disable ? (
+          i18n?.observations || "Start/stop new observation"
+        ) : (
+          <PlayerShortCut type="observation">
+            {i18n?.observations || "Start/stop new observation"}
+          </PlayerShortCut>
+        )
       }
     >
       <TooltipTrigger>{button}</TooltipTrigger>

--- a/src/stories/player/parts/cutterButton.tsx
+++ b/src/stories/player/parts/cutterButton.tsx
@@ -65,6 +65,8 @@ export const Cutter = ({
     </StyledButton>
   );
 
+  if (disable && !i18n?.observationsDisable) return button;
+
   const appendTo = document.getElementById("cutter-tooltip-trigger") || undefined;
 
   return (
@@ -75,7 +77,7 @@ export const Cutter = ({
       appendToNode={appendTo}
       content={
         disable ? (
-          i18n?.observations || "Start/stop new observation"
+          i18n?.observationsDisable
         ) : (
           <PlayerShortCut type="observation">
             {i18n?.observations || "Start/stop new observation"}


### PR DESCRIPTION
## Summary
- Removed `cutterTooltipText` (unused duplicate of `i18n.observations`) from `PlayerArgs`, `Controls` and `Cutter`
- Introduced `i18n.observationsDisable`: a dedicated i18n key for the tooltip shown when the Cutter button is disabled, separate from `i18n.observations` (used when enabled)
- When enabled, the Cutter tooltip always shows the "S" shortcut hint (via `PlayerShortCut`), using `i18n.observations` with a default fallback text
- When disabled, the tooltip shows only if `i18n.observationsDisable` is provided (plain text, no shortcut tag); if not provided, no tooltip is shown at all
- The `S` keyboard shortcut for start/stop observation is now ignored when `disableCutter` is true, matching the tooltip state

## Test plan
- [ ] Storybook `Organisms/Player > CutterDisabled`: hover the disabled Cutter button, verify tooltip shows the `observationsDisable` text (no "S" tag)
- [ ] Storybook `Organisms/Player > AudioPlayerWithBookmarks` (enabled): hover Cutter button, verify tooltip shows "S" shortcut tag
- [ ] Disable the Cutter without passing `i18n.observationsDisable`: verify no tooltip appears
- [ ] With Cutter disabled, press "S" and verify no observation is started
- [ ] With Cutter enabled, press "S" and verify observation starts/stops as before